### PR TITLE
Keyboard Shortcuts!! :tada: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Phase 2 completed!!
     - [ ] Transform items (resize) (Low priority)
     - [ ] Rotate items (Low priority)
 - [x] Undo/redo support
+- [x] Basic keybinding support
 - [ ] Saving the drawings
 - [ ] Exporting drawings to PNGs
-- [ ] Shortcut keys (including pen buttons)
 - [ ] Image support
 - [ ] Text support
 - [ ] Text formatting like bold, underline, italics, etc.

--- a/src/components/toolbar.h
+++ b/src/components/toolbar.h
@@ -14,8 +14,10 @@ public:
     ~ToolBar();
 
     Tool& curTool() const;
-    void addTool(Tool* tool);
+    void addTool(Tool* tool, ToolID toolID);
     QVector<Tool*> tools() const;
+
+    void changeTool(ToolID toolID);
 
 signals:
     void toolChanged(Tool&);
@@ -23,7 +25,7 @@ signals:
 private:
     QButtonGroup* m_group{};
     QHBoxLayout* m_layout{};
-    QVector<Tool*> m_tools{};
+    std::unordered_map<int, Tool*> m_tools{};
     void createButtons() const;
 
 private slots:

--- a/src/context/uicontext.cpp
+++ b/src/context/uicontext.cpp
@@ -22,6 +22,9 @@
 #include "../tools/erasertool.h"
 #include "../tools/movetool.h"
 
+#include "../keybindings/keybindmanager.h"
+#include "../keybindings/actionmanager.h"
+
 UIContext::UIContext(ApplicationContext* context)
     : QObject{context}, m_applicationContext{context} {}
 
@@ -34,18 +37,20 @@ void UIContext::setUIContext() {
     m_toolBar = new ToolBar(m_applicationContext->parentWidget());
     m_actionBar = new ActionBar(m_applicationContext->parentWidget());
     m_propertyBar = new PropertyBar(m_applicationContext->parentWidget());
+    m_keybindManager = new KeybindManager(m_applicationContext->parentWidget());
+    m_actionManager = new ActionManager(m_applicationContext);
 
     m_propertyManager = new PropertyManager(m_propertyBar);
     m_event = new Event();
 
-    m_toolBar->addTool(new SelectionTool());
-    m_toolBar->addTool(new FreeformTool(*m_propertyManager));
-    m_toolBar->addTool(new RectangleTool(*m_propertyManager));
-    m_toolBar->addTool(new EllipseTool(*m_propertyManager));
-    m_toolBar->addTool(new ArrowTool(*m_propertyManager));
-    m_toolBar->addTool(new LineTool(*m_propertyManager));
-    m_toolBar->addTool(new EraserTool(*m_propertyManager));
-    m_toolBar->addTool(new MoveTool());
+    m_toolBar->addTool(new SelectionTool(), ToolID::SelectionTool);
+    m_toolBar->addTool(new FreeformTool(*m_propertyManager), ToolID::FreeformTool);
+    m_toolBar->addTool(new RectangleTool(*m_propertyManager), ToolID::RectangleTool);
+    m_toolBar->addTool(new EllipseTool(*m_propertyManager), ToolID::EllipseTool);
+    m_toolBar->addTool(new ArrowTool(*m_propertyManager), ToolID::ArrowTool);
+    m_toolBar->addTool(new LineTool(*m_propertyManager), ToolID::LineTool);
+    m_toolBar->addTool(new EraserTool(*m_propertyManager), ToolID::EraserTool);
+    m_toolBar->addTool(new MoveTool(), ToolID::MoveTool);
 
     m_actionBar->addButton("-", 1);
     m_actionBar->addButton("+", 2);
@@ -99,6 +104,14 @@ PropertyBar& UIContext::propertyBar() const {
 
 ActionBar& UIContext::actionBar() const {
     return *m_actionBar;
+}
+
+KeybindManager& UIContext::keybindManager() const {
+    return *m_keybindManager;
+}
+
+ActionManager& UIContext::actionManager() const {
+    return *m_actionManager;
 }
 
 Event& UIContext::event() const {

--- a/src/context/uicontext.h
+++ b/src/context/uicontext.h
@@ -9,6 +9,8 @@ class Event;
 class PropertyManager;
 class Tool;
 class ApplicationContext;
+class KeybindManager;
+class ActionManager;
 
 class UIContext : public QObject {
 public:
@@ -21,6 +23,8 @@ public:
     PropertyBar& propertyBar() const;
     ActionBar& actionBar() const;
     Event& event() const;
+    KeybindManager& keybindManager() const;
+    ActionManager& actionManager() const;
 
 public slots:
     void toolChanged(Tool&);
@@ -30,6 +34,8 @@ private:
     PropertyBar* m_propertyBar{};
     ActionBar* m_actionBar{};
     PropertyManager* m_propertyManager{};
+    KeybindManager* m_keybindManager{};
+    ActionManager* m_actionManager{};
     Event* m_event{nullptr};
 
     ApplicationContext* m_applicationContext;

--- a/src/keybinding-plan.txt
+++ b/src/keybinding-plan.txt
@@ -1,0 +1,25 @@
+Features of the keybinding manager
+- Connect/disconnect shortcuts to an Action object
+- List all Actions
+- Get the list of an Action's keybindings
+- Group Actions based on behaviour
+
+Initial thoughts:
+- Hash table to map keybindings to Actions (map A)
+- Hash table to map Actions to a set of keybindings (map B)
+- The keybind manager provides a registerAction method to insert this action in the manager, even if there are no keybindings for it, so that it can be shown in a list later as an available option.
+- To register a keybinding:
+    1. Check if there is already a connection in map A. If yes -> error
+    2. Add connection in map A
+    3. Insert this keybinding to the set in map B
+    4. Connect signal and slot
+- To deregister a keybinding:
+    1. Check if there is a connection. If no -> error
+    2. Get the associated Action object
+    3. Disconnect signal and slot
+    4. Remove mapping in map A
+    4. Remove this keybinding from this Action's set in map B
+- To list all actions
+    1. Traverse in map B to return a vector of Action objects
+- To group actions
+    1. Each action is going to have an ActionGroup enum or something. When listing all actions in the UI, they will be grouped by this enum. For human readable names, there could be a hashmap to get strings for these enums.

--- a/src/keybindings/action.cpp
+++ b/src/keybindings/action.cpp
@@ -1,0 +1,12 @@
+#include "action.h"
+
+Action::Action(QString name, QString description, std::function<void()> callable, QObject* parent)
+    : m_name{name}, m_description{description}, m_callable{std::move(callable)}, QObject{parent} {}
+
+QString Action::name() const {
+    return m_name;
+}
+
+void Action::run() {
+    m_callable();
+}

--- a/src/keybindings/action.h
+++ b/src/keybindings/action.h
@@ -1,0 +1,31 @@
+#ifndef ACTION_H
+#define ACTION_H
+
+#include <QObject>
+#include <QDebug>
+
+class Action : public QObject {
+Q_OBJECT
+private:
+    QString m_name;
+    QString m_description;
+    std::function<void()> m_callable;
+
+public slots:
+    void run();
+
+public:
+    Action(QString name, QString description, std::function<void()> callable, QObject* parent);
+    QString name() const;
+};
+
+namespace std {
+    template<>
+    struct hash<Action> {
+        size_t operator() (Action& action) const noexcept {
+            return std::hash<QString>{} (action.name());
+        }
+    };
+};
+
+#endif

--- a/src/keybindings/actionmanager.cpp
+++ b/src/keybindings/actionmanager.cpp
@@ -1,0 +1,190 @@
+#include "actionmanager.h"
+#include "keybindmanager.h"
+#include "action.h"
+
+#include "../command/commandhistory.h"
+#include "../components/toolbar.h"
+
+#include "../context/applicationcontext.h"
+#include "../context/spatialcontext.h"
+#include "../context/renderingcontext.h"
+#include "../context/uicontext.h"
+
+ActionManager::ActionManager(ApplicationContext* context)
+    : m_context{context}, QObject(context)
+{
+    KeybindManager& keybindManager {m_context->uiContext().keybindManager()};
+
+    Action* undoAction {new Action{
+        "Undo",
+        "Undo last action",
+        [&](){ this->undo(); },
+        context
+    }};
+
+    Action* redoAction {new Action{
+        "Redo",
+        "Redo last undone action",
+        [&](){ this->redo(); },
+        context
+    }};
+
+    Action* zoomInAction {new Action{
+        "Zoom In",
+        "Zoom in",
+        [&](){ this->zoomIn(); },
+        context
+    }};
+
+    Action* zoomOutAction {new Action{
+        "Zoom Out",
+        "Zoom out",
+        [&](){ this->zoomOut(); },
+        context
+    }};
+
+    Action* increaseThicknessAction {new Action{
+        "Increase Thickness",
+        "Increase brush thickness",
+        [&](){ this->increaseThickness(); },
+        context
+    }};
+
+    Action* decreaseThicknessAction {new Action{
+        "Decrease Thickness",
+        "Decrease brush thickness",
+        [&](){ this->decreaseThickness(); },
+        context
+    }};
+
+    Action* freeformToolAction {new Action{
+        "Freeform Tool",
+        "Switch to freeform drawing tool",
+        [&](){ this->switchToFreeformTool(); },
+        context
+    }};
+
+    Action* eraserToolAction {new Action{
+        "Eraser Tool",
+        "Switch to eraser tool",
+        [&](){ this->switchToEraserTool(); },
+        context
+    }};
+
+    Action* selectionToolAction {new Action{
+        "Selection Tool",
+        "Switch to selection tool",
+        [&](){ this->switchToSelectionTool(); },
+        context
+    }};
+
+    Action* rectangleToolAction {new Action{
+        "Rectangle Tool",
+        "Switch to rectangle drawing tool",
+        [&](){ this->switchToRectangleTool(); },
+        context
+    }};
+
+    Action* ellipseToolAction {new Action{
+        "Ellipse Tool",
+        "Switch to ellipse drawing tool",
+        [&](){ this->switchToEllipseTool(); },
+        context
+    }};
+
+    Action* lineToolAction {new Action{
+        "Line Tool",
+        "Switch to line drawing tool",
+        [&](){ this->switchToLineTool(); },
+        context
+    }};
+
+    Action* arrowToolAction {new Action{
+        "Arrow Tool",
+        "Switch to arrow drawing tool",
+        [&](){ this->switchToArrowTool(); },
+        context
+    }};
+
+    Action* moveToolAction {new Action{
+        "Move Tool",
+        "Switch to move tool",
+        [&](){ this->switchToMoveTool(); },
+        context
+    }};
+
+    keybindManager.addKeybinding(undoAction, "Ctrl+Z");
+    keybindManager.addKeybinding(redoAction, "Ctrl+Y");
+    keybindManager.addKeybinding(zoomInAction, "Ctrl++");
+    keybindManager.addKeybinding(zoomOutAction, "Ctrl+-");
+    keybindManager.addKeybinding(increaseThicknessAction, "]");
+    keybindManager.addKeybinding(decreaseThicknessAction, "[");
+    keybindManager.addKeybinding(freeformToolAction, "P");
+    keybindManager.addKeybinding(eraserToolAction, "E");
+    keybindManager.addKeybinding(selectionToolAction, "S");
+    keybindManager.addKeybinding(rectangleToolAction, "R");
+    keybindManager.addKeybinding(ellipseToolAction, "O");
+    keybindManager.addKeybinding(lineToolAction, "L");
+    keybindManager.addKeybinding(arrowToolAction, "A");
+    keybindManager.addKeybinding(moveToolAction, "M");
+}
+
+void ActionManager::undo() {
+    m_context->spatialContext().commandHistory().undo();
+    m_context->renderingContext().markForRender();
+    m_context->renderingContext().markForUpdate();
+}
+
+void ActionManager::redo() {
+    m_context->spatialContext().commandHistory().redo();
+    m_context->renderingContext().markForRender();
+    m_context->renderingContext().markForUpdate();
+}
+
+void ActionManager::zoomIn() {
+    m_context->renderingContext().setZoomFactor(1);
+}
+
+void ActionManager::zoomOut() {
+    m_context->renderingContext().setZoomFactor(-1);
+}
+
+void ActionManager::switchToFreeformTool() {
+    m_context->uiContext().toolBar().changeTool(ToolID::FreeformTool);
+}
+
+void ActionManager::switchToEraserTool() {
+    m_context->uiContext().toolBar().changeTool(ToolID::EraserTool);
+}
+
+void ActionManager::switchToRectangleTool() {
+    m_context->uiContext().toolBar().changeTool(ToolID::RectangleTool);
+}
+
+void ActionManager::switchToEllipseTool() {
+    m_context->uiContext().toolBar().changeTool(ToolID::EllipseTool);
+}
+
+void ActionManager::switchToLineTool() {
+    m_context->uiContext().toolBar().changeTool(ToolID::LineTool);
+}
+
+void ActionManager::switchToArrowTool() {
+    m_context->uiContext().toolBar().changeTool(ToolID::ArrowTool);
+}
+
+void ActionManager::switchToMoveTool() {
+    m_context->uiContext().toolBar().changeTool(ToolID::MoveTool);
+}
+
+void ActionManager::switchToSelectionTool() {
+    m_context->uiContext().toolBar().changeTool(ToolID::SelectionTool);
+}
+
+void ActionManager::increaseThickness() {
+    // TODO: implement
+}
+
+void ActionManager::decreaseThickness() {
+    // TODO: implement
+}

--- a/src/keybindings/actionmanager.h
+++ b/src/keybindings/actionmanager.h
@@ -1,0 +1,31 @@
+#ifndef ACTIONMANAGER_H
+#define ACTIONMANAGER_H
+
+#include <QObject>
+class ApplicationContext;
+
+class ActionManager : public QObject {
+Q_OBJECT 
+public:
+    ActionManager(ApplicationContext* context);
+
+    void zoomIn();
+    void zoomOut();
+    void undo();
+    void redo();
+    void increaseThickness();
+    void decreaseThickness();
+    void switchToFreeformTool();
+    void switchToEraserTool();
+    void switchToSelectionTool();
+    void switchToRectangleTool();
+    void switchToEllipseTool();
+    void switchToLineTool();
+    void switchToArrowTool();
+    void switchToMoveTool();
+
+private:
+    ApplicationContext* m_context;
+};
+
+#endif  // ACTIONMANAGER_H

--- a/src/keybindings/keybindmanager.cpp
+++ b/src/keybindings/keybindmanager.cpp
@@ -1,0 +1,20 @@
+#include "keybindmanager.h"
+
+KeybindManager::KeybindManager(QObject* parent)
+    : QObject{parent} {}
+
+void KeybindManager::addKeybinding(Action* action, const QString& sequence) {
+    if (m_keyToAction.find(sequence) != m_keyToAction.end())
+        return;
+
+    QShortcut* shortcut;
+    if (m_keyToShortcut.find(sequence) == m_keyToShortcut.end()) {
+        shortcut = new QShortcut{QKeySequence::fromString(sequence), parent()};
+    } else {
+        shortcut = m_keyToShortcut[sequence];
+    }
+
+    QObject::connect(shortcut, &QShortcut::activated, action, &Action::run);
+}
+
+void removeKeybinding(QKeySequence sequence);

--- a/src/keybindings/keybindmanager.h
+++ b/src/keybindings/keybindmanager.h
@@ -1,0 +1,21 @@
+#ifndef KEYBINDMANAGER_H
+#define KEYBINDMANAGER_H
+
+#include <unordered_map>
+#include <QKeySequence>
+#include <QShortcut>
+#include "action.h"
+
+class KeybindManager : public QObject {
+public:
+    KeybindManager(QObject* parent);
+
+    void addKeybinding(Action* action, const QString& sequence);
+    void removeKeybinding(QKeySequence sequence);
+
+private:
+    std::unordered_map<QString, QShortcut*> m_keyToShortcut;
+    std::unordered_map<QString, Action*> m_keyToAction;
+};
+
+#endif  // KEYBINDMANAGER_H

--- a/src/tools/erasertool.cpp
+++ b/src/tools/erasertool.cpp
@@ -126,5 +126,5 @@ void EraserTool::mouseReleased(ApplicationContext* context) {
 }
 
 ToolID EraserTool::id() const {
-    return ToolID::EraserToolID;
+    return ToolID::EraserTool;
 }

--- a/src/tools/freeformtool.cpp
+++ b/src/tools/freeformtool.cpp
@@ -126,5 +126,5 @@ void FreeformTool::mouseReleased(ApplicationContext* context) {
 }
 
 ToolID FreeformTool::id() const {
-    return ToolID::FreeformToolID;
+    return ToolID::FreeformTool;
 }

--- a/src/tools/movetool.cpp
+++ b/src/tools/movetool.cpp
@@ -60,5 +60,5 @@ void MoveTool::mouseReleased(ApplicationContext* context) {
 };
 
 ToolID MoveTool::id() const {
-    return ToolID::MoveToolID;
+    return ToolID::MoveTool;
 }

--- a/src/tools/polygondrawingtool.cpp
+++ b/src/tools/polygondrawingtool.cpp
@@ -96,6 +96,6 @@ void PolygonDrawingTool::mouseReleased(ApplicationContext* context) {
 };
 
 ToolID PolygonDrawingTool::id() const {
-    return ToolID::PolygonDrawingToolID;
+    return ToolID::PolygonDrawingTool;
 }
 

--- a/src/tools/selectiontool/selectiontool.cpp
+++ b/src/tools/selectiontool/selectiontool.cpp
@@ -49,5 +49,5 @@ std::shared_ptr<SelectionToolState> SelectionTool::getCurrentState(ApplicationCo
 }
 
 ToolID SelectionTool::id() const {
-    return ToolID::SelectionToolID;
+    return ToolID::SelectionTool;
 };

--- a/src/tools/tool.h
+++ b/src/tools/tool.h
@@ -7,11 +7,15 @@ class ToolProperty;
 enum class ToolPropertyType;
 
 enum class ToolID {
-    SelectionToolID,
-    FreeformToolID,
-    PolygonDrawingToolID,
-    EraserToolID,
-    MoveToolID
+    SelectionTool,
+    FreeformTool,
+    PolygonDrawingTool,
+    EraserTool,
+    MoveTool,
+    RectangleTool,
+    EllipseTool,
+    LineTool,
+    ArrowTool
 };
 
 // INTERFACE

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -11,6 +11,7 @@
 #include "boardlayout.h"
 #include <QButtonGroup>
 #include <QFile>
+#include <QShortcut>
 
 MainWindow::MainWindow(QWidget* parent) : QWidget(parent) {
     this->m_applyCustomStyles();


### PR DESCRIPTION
I've added support for keyboard shortcuts. A framework has been created with a few shortcuts including:
1. undo/redoo
2. zoom in/out
3. switching between different tools

It's just a matter of implementing more shortcuts now.  
TODO:
- [ ] Allow checking keyboard modifiers while using the tools (E.g., holding shift while drawing a line)
- [ ] Pen button and eraser support (in the future)
- [ ] Ability to change keyboard shortcuts at runtime (halfway there)

Next Up: Ability to save/load drawings